### PR TITLE
add more detailed file naming convention

### DIFF
--- a/site/docs/rfc.md
+++ b/site/docs/rfc.md
@@ -129,10 +129,13 @@ MCP resource requests map to files in the `resources/` directory:
 
 #### 4.1.1 URI Encoding Rules
 
+StaticMCP uses a standardized filename encoding convention to ensure consistent, predictable filenames across all implementations. See the [Filename Encoding Convention](standard#3-filename-encoding-convention) in the standard specification for complete details.
+
+Basic encoding rules:
 1. Remove everything before `://` (inclusive)
-2. `/` refers to directory
-3. No special characters allowed
-4. Ensure resulting filename is valid for target file system
+2. `/` refers to directory structure
+3. Apply StaticMCP filename encoding (Unicode normalization, lowercase, safe characters only)
+4. Handle long filenames with truncation and hashing
 
 ### 4.2 Tool Requests
 


### PR DESCRIPTION
While building the Wikipedia SMG, I noticed that we actually need better file naming schema for both SMG and Bridges to follow. So here's what's added:

### Basic Rules

1. **Unicode normalization**: Decompose accented characters (é → e, ñ → n)
2. **Lowercase conversion**: All characters converted to lowercase
3. **Safe character set**: Keep only a-z, 0-9, -, _
4. **Space handling**: Convert spaces to underscores (_)
5. **Invalid characters**: Replace all other characters with underscores (_)
6. **Length limit**: Maximum 200 characters (leaving room for .json extension)

### Long Filename Handling

When encoded filename exceeds 200 characters:
- Take first 183 characters of encoded name
- Append _ + 16-character hex hash of original title
- Format: `{first_183_chars}_{16_hex_hash}`
- Hash is generated from the original (pre-encoded) title for consistency

### Examples

- `"Hello World"` → `"hello_world"`
- `"François Mitterrand"` → `"francois_mitterrand"`
- `"COVID-19 pandemic"` → `"covid-19_pandemic"`
- `"José María Aznar"` → `"jose_maria_aznar"`
- `"King George III"` → `"king_george_iii"`
